### PR TITLE
Update Dockerfile

### DIFF
--- a/amazonlinux-base/Dockerfile
+++ b/amazonlinux-base/Dockerfile
@@ -5,10 +5,10 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:${AZLINUX_VERSION}
 # install any available security and bugfix updates
 RUN dnf -y update
 # Install packages \
-RUN dnf -y install crypto-policies crypto-policies-scripts openssl dracut-fips && \
-    fips-mode-setup --enable --no-bootcfg && \
-    touch /etc/system-fips && \
-    fips-finish-install --complete \
+RUN dnf -y install crypto-policies crypto-policies-scripts openssl && \
+    # fips-mode-setup --enable --no-bootcfg && \
+    # touch /etc/system-fips && \
+    # fips-finish-install --complete \
     dnf clean all && \
     rm -rf /var/cache/yum \
     rm -rf /var/lib/yum \
@@ -17,6 +17,6 @@ RUN dnf -y install crypto-policies crypto-policies-scripts openssl dracut-fips &
     rm -rf /var/tmp/dnf* \
     rm -rf /tmp/dnf*
 
-ENV OPENSSL_FIPS=1 \
-    OPENSSL_FORCE_FIPS_MODE=1 \
-    LC_ALL=C.UTF-8
+# ENV OPENSSL_FIPS=1 \
+#     OPENSSL_FORCE_FIPS_MODE=1 \
+#     LC_ALL=C.UTF-8


### PR DESCRIPTION
### Deployment changes
Removing FIPS from Al2 base image so we don't need to modify code. FIPS views md5 as an insecure algorithm, so in order to use it we need to modify our code to ignore this.  