### PR TITLE
Update  from default 1Mb to 200Mb in nginx-al conf

### DIFF
--- a/python-nginx/3.9/nginx.conf
+++ b/python-nginx/3.9/nginx.conf
@@ -3,6 +3,9 @@ worker_processes auto;
 error_log /var/log/nginx/error.log notice;
 pid /var/lib/nginx/nginx.pid;
 
+# increase max from default 1m
+client_max_body_size 200m;
+
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
 


### PR DESCRIPTION

Link to JIRA ticket if there is one: [GPE-1774](https://ctds-planx.atlassian.net/browse/GPE-1774)

### Improvements
* Update `client_max_body_size` from default 1Mb to 200Mb in nginx-al base-image 


[GPE-1774]: https://ctds-planx.atlassian.net/browse/GPE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ