### PR TITLE
Place the 'client_max_body_size' param approprately

### DIFF
--- a/python-nginx/3.9/nginx.conf
+++ b/python-nginx/3.9/nginx.conf
@@ -3,9 +3,6 @@ worker_processes auto;
 error_log /var/log/nginx/error.log notice;
 pid /var/lib/nginx/nginx.pid;
 
-# increase max from default 1m
-client_max_body_size 200m;
-
 # Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
 include /usr/share/nginx/modules/*.conf;
 
@@ -24,6 +21,9 @@ http {
     tcp_nopush          on;
     keepalive_timeout   65;
     types_hash_max_size 4096;
+    
+    # increase max from default 1m
+    client_max_body_size 200m;
 
     include             /etc/nginx/mime.types;
     default_type        application/octet-stream;


### PR DESCRIPTION
Link to JIRA ticket if there is one: [GPE-1774](https://ctds-planx.atlassian.net/browse/GPE-1774)

### Improvements
* Fix:  Update `client_max_body_size` from default 1Mb to 200Mb in nginx-al base-image  (previously pushed misconfigured Dockerfile)


[GPE-1774]: https://ctds-planx.atlassian.net/browse/GPE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ