### PR TITLE
HighTier-dev: Copy Fail and OpenSSH fixes.

### DIFF
--- a/amazonlinux-base/2023_hardened/Dockerfile
+++ b/amazonlinux-base/2023_hardened/Dockerfile
@@ -18,6 +18,10 @@ RUN dnf -y update && \
 RUN groupadd -g 1000 gen3 && \
     useradd -m -s /bin/bash -u 1000 -g gen3 gen3
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # FIPS-Ready:
 RUN update-crypto-policies --set FIPS
 

--- a/amazonlinux-base/Dockerfile
+++ b/amazonlinux-base/Dockerfile
@@ -17,6 +17,10 @@ RUN dnf -y install crypto-policies crypto-policies-scripts openssl && \
     rm -rf /var/tmp/dnf* \
     rm -rf /tmp/dnf*
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # ENV OPENSSL_FIPS=1 \
 #     OPENSSL_FORCE_FIPS_MODE=1 \
 #     LC_ALL=C.UTF-8

--- a/ubuntu-fips-base/Dockerfile
+++ b/ubuntu-fips-base/Dockerfile
@@ -97,6 +97,10 @@ RUN apt-get purge -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # Use bash as the default shell
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
Updates for Copy Fail and OpenSSH CVES - please let me know if I hit all the dockerfiles that needed the module disabled. 