### PR TITLE
Fix for OpenSSH Full Root access and Copy Fail vulnerabilities

### DIFF
--- a/amazonlinux-base/2023_hardened/Dockerfile
+++ b/amazonlinux-base/2023_hardened/Dockerfile
@@ -18,8 +18,8 @@ RUN dnf -y update && \
 RUN groupadd -g 1000 gen3 && \
     useradd -m -s /bin/bash -u 1000 -g gen3 gen3
 
-RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
-
+RUN mkdir -p /etc/modprobe.d && \
+    echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
 
 RUN rmmod algif_aead 2>/dev/null || true
 

--- a/amazonlinux-base/2023_hardened/Dockerfile
+++ b/amazonlinux-base/2023_hardened/Dockerfile
@@ -18,7 +18,8 @@ RUN dnf -y update && \
 RUN groupadd -g 1000 gen3 && \
     useradd -m -s /bin/bash -u 1000 -g gen3 gen3
 
-RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
+
 
 RUN rmmod algif_aead 2>/dev/null || true
 

--- a/amazonlinux-base/2023_hardened/Dockerfile
+++ b/amazonlinux-base/2023_hardened/Dockerfile
@@ -18,6 +18,10 @@ RUN dnf -y update && \
 RUN groupadd -g 1000 gen3 && \
     useradd -m -s /bin/bash -u 1000 -g gen3 gen3
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # FIPS-Ready:
 RUN update-crypto-policies --set FIPS
 

--- a/amazonlinux-base/Dockerfile
+++ b/amazonlinux-base/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf -y install crypto-policies crypto-policies-scripts openssl && \
     rm -rf /var/tmp/dnf* \
     rm -rf /tmp/dnf*
 
-RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
 
 RUN rmmod algif_aead 2>/dev/null || true
 

--- a/amazonlinux-base/Dockerfile
+++ b/amazonlinux-base/Dockerfile
@@ -17,7 +17,8 @@ RUN dnf -y install crypto-policies crypto-policies-scripts openssl && \
     rm -rf /var/tmp/dnf* \
     rm -rf /tmp/dnf*
 
-RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
+RUN mkdir -p /etc/modprobe.d && \
+    echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
 
 RUN rmmod algif_aead 2>/dev/null || true
 

--- a/amazonlinux-base/Dockerfile
+++ b/amazonlinux-base/Dockerfile
@@ -17,6 +17,10 @@ RUN dnf -y install crypto-policies crypto-policies-scripts openssl && \
     rm -rf /var/tmp/dnf* \
     rm -rf /tmp/dnf*
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # ENV OPENSSL_FIPS=1 \
 #     OPENSSL_FORCE_FIPS_MODE=1 \
 #     LC_ALL=C.UTF-8

--- a/ubuntu-fips-base/Dockerfile
+++ b/ubuntu-fips-base/Dockerfile
@@ -97,7 +97,7 @@ RUN apt-get purge -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
 
 RUN rmmod algif_aead 2>/dev/null || true
 

--- a/ubuntu-fips-base/Dockerfile
+++ b/ubuntu-fips-base/Dockerfile
@@ -97,6 +97,10 @@ RUN apt-get purge -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+RUN echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+
+RUN rmmod algif_aead 2>/dev/null || true
+
 # Use bash as the default shell
 CMD ["/bin/bash"]
 

--- a/ubuntu-fips-base/Dockerfile
+++ b/ubuntu-fips-base/Dockerfile
@@ -97,7 +97,8 @@ RUN apt-get purge -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
+RUN mkdir -p /etc/modprobe.d && \
+    echo "install algif_aead /bin/false" | tee /etc/modprobe.d/disable-algif.conf
 
 RUN rmmod algif_aead 2>/dev/null || true
 


### PR DESCRIPTION
Module Disable for CVE-2026-35414 (OpenSSH) and CVE-2026-31414 (Copy Fail)

- Fixing base images for AMAZON LINUX 2023 and Ubuntu 24.04